### PR TITLE
Update ripple.js

### DIFF
--- a/js/src/ripple.js
+++ b/js/src/ripple.js
@@ -1,6 +1,6 @@
 var addRippleEffect = function (e) {
     var target = e.target;
-    if (target.className.indexOf("ink") === -1) { return false; }
+    if (target.className.spli(' ').indexOf("ink") === -1) { return false; }
     var rect = target.getBoundingClientRect();
     var ripple = target.querySelector('.ripple');
     if (!ripple) {


### PR DESCRIPTION
Changed checking for "ink" class, instead catching indexOf of string, it will split classes into array and check if "ink" is in array.
Prevents triggering ripple effect on elements with classes like "link" etc.